### PR TITLE
Fixing a minor typo in an import in the SMTP service.

### DIFF
--- a/freepy/services/smtp.py
+++ b/freepy/services/smtp.py
@@ -25,7 +25,7 @@ from zope.interface import implements
 
 from twisted.internet import protocol, reactor, defer
 from twisted.mail import smtp
-from email.Header import Header
+from email.header import Header
 
 import logging
 from freepy import settings


### PR DESCRIPTION
@thomasquintana This is a very small fix to a import. It also removes errors in IDE while importing. 

It is funny that is is importable both ways, but as per the documentation the fix is the way to import it: https://docs.python.org/2/library/email.header.html

