### PR TITLE
Performance Fix using non blocking wait

### DIFF
--- a/freepy/lib/actors/actor.py
+++ b/freepy/lib/actors/actor.py
@@ -29,7 +29,7 @@ class Actor(object):
   An actor is the most basic unit of computation in an actor framework.
   '''
 
-  def __init__(self, runner, *args, **kwargs):
+  def __init__(self, runner):
     self._mailbox = list()
     if isinstance(runner, ActorScheduler):
       self._scheduler = runner
@@ -39,7 +39,7 @@ class Actor(object):
 
     super(Actor, self).__init__()
     # Schedule ourself for execution.
-    proc = ActorProcessor(self, self._mailbox, self._scheduler, self._urn, waiter=self._scheduler._waiter)
+    proc = ActorProcessor(self, self._mailbox, self._scheduler, self._urn)
     proc.start()
 
   @property

--- a/freepy/lib/actors/actor.py
+++ b/freepy/lib/actors/actor.py
@@ -63,5 +63,4 @@ class Actor(object):
 
   def tell(self, message):
     self._mailbox.append(message)
-    if not self._scheduler._waiter.isSet():
-      self._scheduler._waiter.set()
+    self._scheduler.waiter.set()

--- a/freepy/lib/actors/actor.py
+++ b/freepy/lib/actors/actor.py
@@ -39,7 +39,7 @@ class Actor(object):
 
     super(Actor, self).__init__()
     # Schedule ourself for execution.
-    proc = ActorProcessor(self, self._mailbox, self._scheduler, self._urn)
+    proc = ActorProcessor(self, self._mailbox, self._scheduler, self._urn, waiter=self._scheduler._waiter)
     proc.start()
 
   @property
@@ -63,3 +63,5 @@ class Actor(object):
 
   def tell(self, message):
     self._mailbox.append(message)
+    if not self._scheduler._waiter.isSet():
+      self._scheduler._waiter.set()

--- a/freepy/lib/actors/actor.py
+++ b/freepy/lib/actors/actor.py
@@ -50,7 +50,6 @@ class Actor(object):
   def urn(self):
     return self._urn
 
-
   def receive(self, message):
     '''
     This method processes incoming messages.
@@ -63,4 +62,4 @@ class Actor(object):
 
   def tell(self, message):
     self._mailbox.append(message)
-    self._scheduler.waiter.set()
+    self._scheduler.notify()

--- a/freepy/lib/actors/actor.py
+++ b/freepy/lib/actors/actor.py
@@ -29,7 +29,7 @@ class Actor(object):
   An actor is the most basic unit of computation in an actor framework.
   '''
 
-  def __init__(self, runner):
+  def __init__(self, runner, *args, **kwargs):
     self._mailbox = list()
     if isinstance(runner, ActorScheduler):
       self._scheduler = runner

--- a/freepy/lib/actors/actor_processor.py
+++ b/freepy/lib/actors/actor_processor.py
@@ -143,10 +143,7 @@ class ActorProcessor(object):
         self._actor.on_start()
     self._state = ACTOR_PROCESSOR_IDLE
     self._scheduler.schedule(self)
-    self._scheduler_waiter.set()
+    self._scheduler.waiter.set()
 
   def tell(self, message):
     self._mailbox.append(message)
-    # self._logger.info('GOT MESSAGE!')
-    # if not self._scheduler_waiter.isSet():
-    #   self._scheduler_waiter.set()

--- a/freepy/lib/actors/actor_processor.py
+++ b/freepy/lib/actors/actor_processor.py
@@ -42,7 +42,6 @@ class ActorProcessor(object):
     self._actor = actor
     self._mailbox = mailbox
     self._scheduler = scheduler
-    self._scheduler_waiter = kwargs.get('waiter')
     self._state = None
     # Run-time statistics.
     self._slice_msg_count = 0

--- a/freepy/lib/actors/actor_processor.py
+++ b/freepy/lib/actors/actor_processor.py
@@ -142,7 +142,7 @@ class ActorProcessor(object):
         self._actor.on_start()
     self._state = ACTOR_PROCESSOR_IDLE
     self._scheduler.schedule(self)
-    self._scheduler.waiter.set()
+    self._scheduler.notify()
 
   def tell(self, message):
     self._mailbox.append(message)

--- a/freepy/lib/actors/actor_processor.py
+++ b/freepy/lib/actors/actor_processor.py
@@ -36,7 +36,7 @@ class ActorProcessor(object):
   the actors managed by a particular scheduler.
   '''
 
-  def __init__(self, actor, mailbox, scheduler, urn, **kwargs):
+  def __init__(self, actor, mailbox, scheduler, urn):
     super(ActorProcessor, self).__init__()
     self._logger = logging.getLogger(object_fqn(self))
     self._actor = actor

--- a/freepy/lib/actors/actor_processor.py
+++ b/freepy/lib/actors/actor_processor.py
@@ -36,12 +36,13 @@ class ActorProcessor(object):
   the actors managed by a particular scheduler.
   '''
 
-  def __init__(self, actor, mailbox, scheduler, urn):
+  def __init__(self, actor, mailbox, scheduler, urn, **kwargs):
     super(ActorProcessor, self).__init__()
     self._logger = logging.getLogger(object_fqn(self))
     self._actor = actor
     self._mailbox = mailbox
     self._scheduler = scheduler
+    self._scheduler_waiter = kwargs.get('waiter')
     self._state = None
     # Run-time statistics.
     self._slice_msg_count = 0
@@ -142,6 +143,10 @@ class ActorProcessor(object):
         self._actor.on_start()
     self._state = ACTOR_PROCESSOR_IDLE
     self._scheduler.schedule(self)
+    self._scheduler_waiter.set()
 
   def tell(self, message):
     self._mailbox.append(message)
+    # self._logger.info('GOT MESSAGE!')
+    # if not self._scheduler_waiter.isSet():
+    #   self._scheduler_waiter.set()

--- a/freepy/lib/actors/actor_scheduler.py
+++ b/freepy/lib/actors/actor_scheduler.py
@@ -47,6 +47,10 @@ class ActorScheduler(object):
     self._total_msgs_processed = 0
 
   @property
+  def waiter(self):
+    return self._waiter
+
+  @property
   def is_running(self):
     return self._running or self._stop_run_time is None
 
@@ -74,13 +78,7 @@ class ActorScheduler(object):
                        len(self._waiting_actor_procs)
     # Start the scheduler loop.
     self._start_run_time = time.time()
-    must_wait = False
     while self._running or n_running_actors > 0:
-      # if must_wait:
-      #   self._waiter.clear()
-      #   self._waiter.wait()
-      #   must_wait = False
-
       # Check the idle actor processors list for actors with new messages.
       if len(self._idle_actor_procs) > 0:
         temp = list()
@@ -96,14 +94,8 @@ class ActorScheduler(object):
       # If we don't have work to do back off for random periods of time
       # that never exceed one second at a time.
       if len(self._ready_actor_procs) == 0:
-        # time.sleep(1 * random.uniform(0, 0.25))
-        # continue
-        # if not self._waiter.isSet():
-        # self._logger.info('waiting boss')
         self._waiter.wait()
         self._waiter.clear()
-        # must_wait = True
-        continue
 
       # Once we have some work to do allow actor processors in the current
       # ready queue to take over the process.

--- a/freepy/lib/actors/actor_scheduler.py
+++ b/freepy/lib/actors/actor_scheduler.py
@@ -18,7 +18,6 @@
 # Thomas Quintana <quintana.thomas@gmail.com>
 
 import logging
-import random
 import threading
 import time
 
@@ -40,15 +39,18 @@ class ActorScheduler(object):
     self._ready_actor_procs = list()
     self._waiting_actor_procs = list()
     self._running = False
-    self._waiter = threading.Event()
+    self._barrier = threading.Event()
     # Run-time statistics.
     self._start_run_time = None
     self._stop_run_time = None
     self._total_msgs_processed = 0
 
   @property
-  def waiter(self):
-    return self._waiter
+  def barrier(self):
+    return self._barrier
+
+  def notify(self):
+    self._barrier.set()
 
   @property
   def is_running(self):
@@ -94,8 +96,8 @@ class ActorScheduler(object):
       # If we don't have work to do back off for random periods of time
       # that never exceed one second at a time.
       if len(self._ready_actor_procs) == 0:
-        self._waiter.wait()
-        self._waiter.clear()
+        self._barrier.wait()
+        self._barrier.clear()
 
       # Once we have some work to do allow actor processors in the current
       # ready queue to take over the process.

--- a/freepy/lib/actors/actor_scheduler.py
+++ b/freepy/lib/actors/actor_scheduler.py
@@ -19,6 +19,7 @@
 
 import logging
 import random
+import threading
 import time
 
 from freepy.lib.actors.exceptions.interrupt_exception import InterruptException
@@ -39,6 +40,7 @@ class ActorScheduler(object):
     self._ready_actor_procs = list()
     self._waiting_actor_procs = list()
     self._running = False
+    self._waiter = threading.Event()
     # Run-time statistics.
     self._start_run_time = None
     self._stop_run_time = None
@@ -72,7 +74,13 @@ class ActorScheduler(object):
                        len(self._waiting_actor_procs)
     # Start the scheduler loop.
     self._start_run_time = time.time()
+    must_wait = False
     while self._running or n_running_actors > 0:
+      # if must_wait:
+      #   self._waiter.clear()
+      #   self._waiter.wait()
+      #   must_wait = False
+
       # Check the idle actor processors list for actors with new messages.
       if len(self._idle_actor_procs) > 0:
         temp = list()
@@ -88,8 +96,15 @@ class ActorScheduler(object):
       # If we don't have work to do back off for random periods of time
       # that never exceed one second at a time.
       if len(self._ready_actor_procs) == 0:
-        time.sleep(1 * random.uniform(0, 0.25))
+        # time.sleep(1 * random.uniform(0, 0.25))
+        # continue
+        # if not self._waiter.isSet():
+        # self._logger.info('waiting boss')
+        self._waiter.wait()
+        self._waiter.clear()
+        # must_wait = True
         continue
+
       # Once we have some work to do allow actor processors in the current
       # ready queue to take over the process.
       while len(self._ready_actor_procs) > 0:


### PR DESCRIPTION
Don't merge yet. I still have some more things to try out. 

Have used threading.event to illustrate how other threads can help unblock a waiting thread. This uses a generic event to talk across threads. This fix might be needed in other sections, but at the moment, all tests pass properly.

The logic is pretty simple really:

- The scheduler waits for things to happen
- The people that want things to happen let the scheduler know

I will also work on making the code more semantically pleasing. Like change `.set()` to `.continue()` or something like that so it becomes more readable.